### PR TITLE
Honor MINIO_REGION_NAME when creating buckets

### DIFF
--- a/2020/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
+++ b/2020/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
@@ -32,6 +32,7 @@ export MINIO_CERTSDIR="/certs"
 export MINIO_SKIP_CLIENT="${MINIO_SKIP_CLIENT:-no}"
 export MINIO_DISTRIBUTED_MODE_ENABLED="${MINIO_DISTRIBUTED_MODE_ENABLED:-no}"
 export MINIO_DEFAULT_BUCKETS="${MINIO_DEFAULT_BUCKETS:-}"
+export MINIO_REGION_NAME="${MINIO_REGION_NAME:-}"
 export MINIO_PORT_NUMBER="${MINIO_PORT_NUMBER:-9000}"
 export MINIO_DAEMON_USER="minio"
 export MINIO_DAEMON_GROUP="minio"
@@ -220,7 +221,11 @@ minio_create_default_buckets() {
         info "Creating default buckets..."
         for b in "${buckets[@]}"; do
             if ! minio_client_bucket_exists "local/${b}"; then
-                minio_client_execute mb "local/${b}"
+                if [[ -n "$MINIO_REGION_NAME" ]]; then
+                  minio_client_execute mb "--region" "${MINIO_REGION_NAME}" "local/${b}"
+                else
+                  minio_client_execute mb "local/${b}"
+                fi
             else
                 info "Bucket local/${b} already exists, skipping creation."
             fi


### PR DESCRIPTION
**Description of the change**
Honor `MINIO_REGION_NAME` when `MINIO_DEFAULT_BUCKETS` is defined.

If you define MINIO_REGION_NAME for minio server then you need to be explicit when creating buckets or minio client will rise an error as default client region won't match server region.

**Benefits**

Some SDKs requires a region to interact with minio properly. MINIO_DEFAULT_BUCKETS feature is great but is broken if you need to use a different region than the default one.

**Possible drawbacks**

I've hadn't seen any other possible features provided by bitnami-docker-minio image that might be affected by the change.

**Applicable issues**

- fixes #4 

**Additional information**
Example:

Without `MINIO_REGION_NAME`:
```bash
$ cat docker-compose.yml
 
version: '3'
services:
  minio:
    build: /Users/mac/github.com/danfaizer/bitnami-docker-minio/2020/debian-10
    ports:
      - 9000:9000
    environment:
      - MINIO_ACCESS_KEY=minio-access-key
      - MINIO_SECRET_KEY=minio-secret-key
      - MINIO_DEFAULT_BUCKETS=bucket1,bucket2

$ aws --endpoint-url http://localhost:9000 s3api get-bucket-location --bucket bucket1
{
    "LocationConstraint": null
}
```

With `MINIO_REGION_NAME`:
```bash
$ cat docker-compose.yml

version: '3'
services:
  minio:
    build: /Users/mac/github.com/danfaizer/bitnami-docker-minio/2020/debian-10
    ports:
      - 9000:9000
    environment:
      - MINIO_REGION_NAME=barcelona
      - MINIO_ACCESS_KEY=minio-access-key
      - MINIO_SECRET_KEY=minio-secret-key
      - MINIO_DEFAULT_BUCKETS=bucket1,bucket2

$ aws --endpoint-url http://localhost:9000 s3api get-bucket-location --bucket bucket1
{
    "LocationConstraint": "barcelona"
}
```