### PR TITLE
Enable to specify default bucket policy for MINIO_DEFAULT_BUCKETS

### DIFF
--- a/2020/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
+++ b/2020/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
@@ -228,8 +228,8 @@ minio_create_default_buckets() {
         read -r -a buckets <<< "$(tr ',;' ' ' <<< "${MINIO_DEFAULT_BUCKETS}")"
         info "Creating default buckets..."
         for b in "${buckets[@]}"; do
-		    read -r -a Options <<< "$(tr ':' ' ' <<< "${b}")"
-            if ! minio_client_bucket_exists "local/${b}"; then
+            read -r -a Options <<< "$(tr ':' ' ' <<< "${b}")"
+            if ! minio_client_bucket_exists "local/${Options[0]}"; then
                 if [[ -n "${MINIO_REGION_NAME:-}" ]]; then
                     minio_client_execute mb "--region" "${MINIO_REGION_NAME}" "local/${Options[0]}"
                 else

--- a/2020/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
+++ b/2020/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
@@ -228,14 +228,19 @@ minio_create_default_buckets() {
         read -r -a buckets <<< "$(tr ',;' ' ' <<< "${MINIO_DEFAULT_BUCKETS}")"
         info "Creating default buckets..."
         for b in "${buckets[@]}"; do
+		    read -r -a Options <<< "$(tr ':' ' ' <<< "${b}")"
             if ! minio_client_bucket_exists "local/${b}"; then
                 if [[ -n "${MINIO_REGION_NAME:-}" ]]; then
-                    minio_client_execute mb "--region" "${MINIO_REGION_NAME}" "local/${b}"
+                    minio_client_execute mb "--region" "${MINIO_REGION_NAME}" "local/${Options[0]}"
                 else
-                    minio_client_execute mb "local/${b}"
+                    minio_client_execute mb "local/${Options[0]}"
+                fi
+                if [ ${#Options[@]} -eq 2 ]; then
+                    info "Setting policy ${Options[1]} for local bucket ${Options[0]}"
+                    minio_client_execute policy set "${Options[1]}" local/"${Options[0]}"/
                 fi
             else
-                info "Bucket local/${b} already exists, skipping creation."
+                info "Bucket local/${Options[0]} already exists, skipping creation."
             fi
         done
     fi

--- a/2020/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
+++ b/2020/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
@@ -228,19 +228,19 @@ minio_create_default_buckets() {
         read -r -a buckets <<< "$(tr ',;' ' ' <<< "${MINIO_DEFAULT_BUCKETS}")"
         info "Creating default buckets..."
         for b in "${buckets[@]}"; do
-            read -r -a Options <<< "$(tr ':' ' ' <<< "${b}")"
-            if ! minio_client_bucket_exists "local/${Options[0]}"; then
+            read -r -a bucket_info <<< "$(tr ':' ' ' <<< "${b}")"
+            if ! minio_client_bucket_exists "local/${bucket_info[0]}"; then
                 if [[ -n "${MINIO_REGION_NAME:-}" ]]; then
-                    minio_client_execute mb "--region" "${MINIO_REGION_NAME}" "local/${Options[0]}"
+                    minio_client_execute mb "--region" "${MINIO_REGION_NAME}" "local/${bucket_info[0]}"
                 else
-                    minio_client_execute mb "local/${Options[0]}"
+                    minio_client_execute mb "local/${bucket_info[0]}"
                 fi
-                if [ ${#Options[@]} -eq 2 ]; then
-                    info "Setting policy ${Options[1]} for local bucket ${Options[0]}"
-                    minio_client_execute policy set "${Options[1]}" local/"${Options[0]}"/
+                if [ ${#bucket_info[@]} -eq 2 ]; then
+                    info "Setting policy ${bucket_info[1]} for local bucket ${bucket_info[0]}"
+                    minio_client_execute policy set "${bucket_info[1]}" local/"${bucket_info[0]}"/
                 fi
             else
-                info "Bucket local/${Options[0]} already exists, skipping creation."
+                info "Bucket local/${bucket_info[0]} already exists, skipping creation."
             fi
         done
     fi


### PR DESCRIPTION
**Description of the change**

Enables you to specify a policy for the newly created MINIO_DEFAULT_BUCKETS like:
MINIO_DEFAULT_BUCKETS=mynewpubrw:public,mynewro:download,normalbucket,.....

**Benefits**

Create eg a public bucket on initialisation

**Possible drawbacks**

None. "Normal" definitions will still work

**Applicable issues**
/
**Additional information**
/