### PR TITLE
MinIO - Add support for ellipsis syntax on distributed mode

### DIFF
--- a/2021/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
@@ -69,7 +69,30 @@ EOF
 #   Boolean
 #########################
 is_distributed_ellipses_syntax() {
-    [[ -n "${MINIO_DISTRIBUTED_NODES}" ]] && [[ $MINIO_DISTRIBUTED_NODES == *"..."* ]]
+    ! is_empty_value "$MINIO_DISTRIBUTED_NODES" && [[ $MINIO_DISTRIBUTED_NODES == *"..."* ]]
+}
+
+########################
+# Obtain the list of drives used by the MinIO node
+# Globals:
+#   MINIO_DISTRIBUTED_NODES
+# Arguments:
+#   None
+# Returns:
+#   Array with MinIO node drives
+#########################
+minio_distributed_drives() {
+    local -a drives=()
+    local -a nodes
+
+    if ! is_empty_value "$MINIO_DISTRIBUTED_NODES"; then
+        read -r -a nodes <<< "$(tr ',;' ' ' <<< "${MINIO_DISTRIBUTED_NODES}")"
+        for node in "${nodes[@]}"; do
+            drive="$(parse_uri "${MINIO_SCHEME}://${node}" "path")"
+            drives+=("$drive")
+        done
+    fi
+    echo "${drives[@]}"
 }
 
 ########################

--- a/2021/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
@@ -201,7 +201,7 @@ minio_validate() {
             print_validation_error "Distributed mode is enabled. Nodes must be indicated setting the environment variable MINIO_DISTRIBUTED_NODES"
         else
             read -r -a nodes <<< "$(tr ',;' ' ' <<< "${MINIO_DISTRIBUTED_NODES}")"
-            if ! is_distributed_ellipses_syntax && [[ "${#nodes[@]}" -lt 4 ]] || (( "${#nodes[@]}" % 2 )); then
+            if ! is_distributed_ellipses_syntax && ([[ "${#nodes[@]}" -lt 4 ]] || (( "${#nodes[@]}" % 2 ))); then
                 print_validation_error "Number of nodes must even and greater than 4."
             fi
         fi

--- a/2021/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/libminio.sh
@@ -69,14 +69,7 @@ EOF
 #   Boolean
 #########################
 is_distributed_ellipses_syntax() {
-    local return_value=1
-
-    if [[ -n "${MINIO_DISTRIBUTED_NODES}" ]]; then
-        if [[ $MINIO_DISTRIBUTED_NODES == *"..."* ]]; then
-            return_value=0
-        fi
-    fi
-    return $return_value
+    [[ -n "${MINIO_DISTRIBUTED_NODES}" ]] && [[ $MINIO_DISTRIBUTED_NODES == *"..."* ]]
 }
 
 ########################
@@ -208,10 +201,8 @@ minio_validate() {
             print_validation_error "Distributed mode is enabled. Nodes must be indicated setting the environment variable MINIO_DISTRIBUTED_NODES"
         else
             read -r -a nodes <<< "$(tr ',;' ' ' <<< "${MINIO_DISTRIBUTED_NODES}")"
-            if ! is_distributed_ellipses_syntax; then
-                if [[ "${#nodes[@]}" -lt 4 ]] || (( "${#nodes[@]}" % 2 )); then
-                    print_validation_error "Number of nodes must even and greater than 4."
-                fi
+            if ! is_distributed_ellipses_syntax && [[ "${#nodes[@]}" -lt 4 ]] || (( "${#nodes[@]}" % 2 )); then
+                print_validation_error "Number of nodes must even and greater than 4."
             fi
         fi
     else

--- a/2021/debian-10/rootfs/opt/bitnami/scripts/minio/run.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/minio/run.sh
@@ -21,7 +21,11 @@ ARGS=("server" "--certs-dir" "${MINIO_CERTSDIR}")
 if is_boolean_yes "$MINIO_DISTRIBUTED_MODE_ENABLED"; then
     read -r -a nodes <<< "$(tr ',;' ' ' <<< "${MINIO_DISTRIBUTED_NODES}")"
     for node in "${nodes[@]}"; do
-        ARGS+=("http://${node}:${MINIO_PORT_NUMBER}${MINIO_DATADIR}")
+        if is_distributed_ellipses_syntax; then
+            ARGS+=("${MINIO_SCHEME}://${node}")
+        else
+            ARGS+=("${MINIO_SCHEME}://${node}:${MINIO_PORT_NUMBER}/${MINIO_DATADIR}")
+        fi
     done
 else
     ARGS+=("--address" ":${MINIO_PORT_NUMBER}" "${MINIO_DATADIR}")

--- a/2021/debian-10/rootfs/opt/bitnami/scripts/minio/setup.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/minio/setup.sh
@@ -30,11 +30,17 @@ else
     minio_start_bg
     # Ensure MinIO Client is stopped when this script ends.
     trap "minio_stop" EXIT
-    # Configure MinIO Client to use local MinIO server
-    minio_client_configure_local "${MINIO_DATADIR}/.minio.sys/config/config.json"
     if is_boolean_yes "$MINIO_DISTRIBUTED_MODE_ENABLED"; then
+        if is_distributed_ellipses_syntax; then
+            read -r -a drives <<< "$(minio_distributed_drives)"
+            minio_client_configure_local "/${drives[0]}/.minio.sys/config/config.json"
+        else
+            minio_client_configure_local "${MINIO_DATADIR}/.minio.sys/config/config.json"
+        fi
         # Wait for other clients (distribute mode)
         sleep 5
+    else
+        minio_client_configure_local "${MINIO_DATADIR}/.minio.sys/config/config.json"
     fi
     # Create default buckets
     minio_create_default_buckets

--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ services:
       - MINIO_SECRET_KEY=minio-secret-key
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio1,minio2,minio3,minio4
-      - MINIO_SKIP_CLIENT=yes
   minio2:
     image: 'bitnami/minio:latest'
     environment:
@@ -273,7 +272,6 @@ services:
       - MINIO_SECRET_KEY=minio-secret-key
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio1,minio2,minio3,minio4
-      - MINIO_SKIP_CLIENT=yes
   minio3:
     image: 'bitnami/minio:latest'
     environment:
@@ -281,7 +279,6 @@ services:
       - MINIO_SECRET_KEY=minio-secret-key
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio1,minio2,minio3,minio4
-      - MINIO_SKIP_CLIENT=yes
   minio4:
     image: 'bitnami/minio:latest'
     environment:
@@ -289,7 +286,6 @@ services:
       - MINIO_SECRET_KEY=minio-secret-key
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio1,minio2,minio3,minio4
-      - MINIO_SKIP_CLIENT=yes
 ```
 
 MinIO(R) also supports ellipsis syntax (`{1..n}`) to list the MinIO(R) node hosts, where `n` is the number of nodes. This syntax is also valid to use multiple drives (`{1..m}`) on each MinIO(R) node, where `n` is the number of drives per node. You can use the Docker Compose below to create an 2-node distributed MinIO(R) setup with 2 drives per node:
@@ -308,7 +304,6 @@ services:
       - MINIO_SECRET_KEY=miniosecret
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio-{0...1}/data-{0...1}
-      - MINIO_SKIP_CLIENT=yes
   minio-1:
     image: 'bitnami/minio:latest'
     volumes:
@@ -319,7 +314,6 @@ services:
       - MINIO_SECRET_KEY=miniosecret
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio-{0...1}/data-{0...1}
-      - MINIO_SKIP_CLIENT=yes
 
 volumes:
   minio_0_data_0:

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ services:
       - MINIO_SKIP_CLIENT=yes
 ```
 
-MinIO(R) also supports ellipsis syntax (`{1..n}`) to list the MinIO(R) node hosts, where `n` is the number of nodes. This syntax is also valid to use multiple drives (`{1..m}`) on each MinIO(R) node, where `n` is the number of drives per node. You can use the Docker Compose below to create an 4-node distributed MinIO(R) setup with 2 drives per node:
+MinIO(R) also supports ellipsis syntax (`{1..n}`) to list the MinIO(R) node hosts, where `n` is the number of nodes. This syntax is also valid to use multiple drives (`{1..m}`) on each MinIO(R) node, where `n` is the number of drives per node. You can use the Docker Compose below to create an 2-node distributed MinIO(R) setup with 2 drives per node:
 
 ```yaml
 version: '2'
@@ -300,36 +300,36 @@ version: '2'
 services:
   minio-0:
     image: 'bitnami/minio:latest'
+    volumes:
+      - 'minio_0_data_0:/data-0'
+      - 'minio_0_data_1:/data-1'
     environment:
       - MINIO_ACCESS_KEY=minio
       - MINIO_SECRET_KEY=miniosecret
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
-      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_DISTRIBUTED_NODES=minio-{0...1}/data-{0...1}
       - MINIO_SKIP_CLIENT=yes
   minio-1:
     image: 'bitnami/minio:latest'
+    volumes:
+      - 'minio_1_data_0:/data-0'
+      - 'minio_1_data_1:/data-1'
     environment:
-      - MINIO_ACCESS_KEY=minio-access-key
-      - MINIO_SECRET_KEY=minio-secret-key
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=miniosecret
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
-      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_DISTRIBUTED_NODES=minio-{0...1}/data-{0...1}
       - MINIO_SKIP_CLIENT=yes
-  minio-2:
-    image: 'bitnami/minio:latest'
-    environment:
-      - MINIO_ACCESS_KEY=minio-access-key
-      - MINIO_SECRET_KEY=minio-secret-key
-      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
-      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
-      - MINIO_SKIP_CLIENT=yes
-  minio-3:
-    image: 'bitnami/minio:latest'
-    environment:
-      - MINIO_ACCESS_KEY=minio-access-key
-      - MINIO_SECRET_KEY=minio-secret-key
-      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
-      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
-      - MINIO_SKIP_CLIENT=yes
+
+volumes:
+  minio_0_data_0:
+    driver: local
+  minio_0_data_1:
+    driver: local
+  minio_1_data_0:
+    driver: local
+  minio_1_data_1:
+    driver: local
 ```
 
 Find more information about the Distributed Mode in the [MinIO(R) documentation](https://docs.min.io/docs/distributed-minio-quickstart-guide.html).

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ services:
 You can configure MinIO(R) in Distributed Mode to setup a highly-available storage system. To do so, the environment variables below **must** be set on each node:
 
 * `MINIO_DISTRIBUTED_MODE_ENABLED`: Set it to 'yes' to enable Distributed Mode.
-* `MINIO_DISTRIBUTED_NODES`: List of MiNIO nodes hosts. Available separatos are ' ', ',' and ';'.
+* `MINIO_DISTRIBUTED_NODES`: List of MinIO(R) nodes hosts. Available separators are ' ', ',' and ';'.
 * `MINIO_ACCESS_KEY`: MinIO(R) server Access Key. Must be common on every node.
 * `MINIO_SECRET_KEY`: MinIO(R) server Secret Key. Must be common on every node.
 
@@ -265,6 +265,7 @@ services:
       - MINIO_SECRET_KEY=minio-secret-key
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio1,minio2,minio3,minio4
+      - MINIO_SKIP_CLIENT=yes
   minio2:
     image: 'bitnami/minio:latest'
     environment:
@@ -272,6 +273,7 @@ services:
       - MINIO_SECRET_KEY=minio-secret-key
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio1,minio2,minio3,minio4
+      - MINIO_SKIP_CLIENT=yes
   minio3:
     image: 'bitnami/minio:latest'
     environment:
@@ -279,6 +281,7 @@ services:
       - MINIO_SECRET_KEY=minio-secret-key
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio1,minio2,minio3,minio4
+      - MINIO_SKIP_CLIENT=yes
   minio4:
     image: 'bitnami/minio:latest'
     environment:
@@ -286,6 +289,47 @@ services:
       - MINIO_SECRET_KEY=minio-secret-key
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio1,minio2,minio3,minio4
+      - MINIO_SKIP_CLIENT=yes
+```
+
+MinIO(R) also supports ellipsis syntax (`{1..n}`) to list the MinIO(R) node hosts, where `n` is the number of nodes. This syntax is also valid to use multiple drives (`{1..m}`) on each MinIO(R) node, where `n` is the number of drives per node. You can use the Docker Compose below to create an 4-node distributed MinIO(R) setup with 2 drives per node:
+
+```yaml
+version: '2'
+
+services:
+  minio-0:
+    image: 'bitnami/minio:latest'
+    environment:
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=miniosecret
+      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
+      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_SKIP_CLIENT=yes
+  minio-1:
+    image: 'bitnami/minio:latest'
+    environment:
+      - MINIO_ACCESS_KEY=minio-access-key
+      - MINIO_SECRET_KEY=minio-secret-key
+      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
+      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_SKIP_CLIENT=yes
+  minio-2:
+    image: 'bitnami/minio:latest'
+    environment:
+      - MINIO_ACCESS_KEY=minio-access-key
+      - MINIO_SECRET_KEY=minio-secret-key
+      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
+      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_SKIP_CLIENT=yes
+  minio-3:
+    image: 'bitnami/minio:latest'
+    environment:
+      - MINIO_ACCESS_KEY=minio-access-key
+      - MINIO_SECRET_KEY=minio-secret-key
+      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
+      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_SKIP_CLIENT=yes
 ```
 
 Find more information about the Distributed Mode in the [MinIO(R) documentation](https://docs.min.io/docs/distributed-minio-quickstart-guide.html).

--- a/docker-compose-distributed-multidrive.yml
+++ b/docker-compose-distributed-multidrive.yml
@@ -1,0 +1,103 @@
+version: '2'
+
+services:
+  prepare-data:
+    image: 'docker.io/bitnami/bitnami-shell:10'
+    command:
+      - /bin/bash
+      - -ec
+      - |
+        chmod -R g+rwX /data-0-0 /data-0-1 /data-1-0 /data-1-1 /data-2-0 /data-2-1 /data-3-0 /data-3-1
+    volumes:
+      - 'minio_0_data_0:/data-0-0'
+      - 'minio_0_data_1:/data-0-1'
+      - 'minio_1_data_0:/data-1-0'
+      - 'minio_1_data_1:/data-1-1'
+      - 'minio_2_data_0:/data-2-0'
+      - 'minio_2_data_1:/data-2-1'
+      - 'minio_3_data_0:/data-3-0'
+      - 'minio_3_data_1:/data-3-1'
+  minio-0:
+    image: 'docker.io/bitnami/minio:2021-debian-10'
+    ports:
+      - 9000:9000
+    volumes:
+      - 'minio_0_data_0:/data-0'
+      - 'minio_0_data_1:/data-1'
+    environment:
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=miniosecret
+      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
+      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_SKIP_CLIENT=yes
+    depends_on:
+      - prepare-data
+  minio-1:
+    image: 'docker.io/bitnami/minio:2021-debian-10'
+    volumes:
+      - 'minio_1_data_0:/data-0'
+      - 'minio_1_data_1:/data-1'
+    environment:
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=miniosecret
+      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
+      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_SKIP_CLIENT=yes
+    depends_on:
+      - prepare-data
+  minio-2:
+    image: 'docker.io/bitnami/minio:2021-debian-10'
+    volumes:
+      - 'minio_2_data_0:/data-0'
+      - 'minio_2_data_1:/data-1'
+    environment:
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=miniosecret
+      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
+      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_SKIP_CLIENT=yes
+    depends_on:
+      - prepare-data
+  minio-3:
+    image: 'docker.io/bitnami/minio:2021-debian-10'
+    volumes:
+      - 'minio_3_data_0:/data-0'
+      - 'minio_3_data_1:/data-1'
+    environment:
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=miniosecret
+      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
+      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_SKIP_CLIENT=yes
+    depends_on:
+      - prepare-data
+  minio-client:
+    image: 'docker.io/bitnami/minio-client:2021-debian-10'
+    entrypoint:
+      - sleep
+    command:
+      - infinity
+    environment:
+      - MINIO_SERVER_HOST=minio-0
+      - MINIO_SERVER_ACCESS_KEY=minio
+      - MINIO_SERVER_SECRET_KEY=miniosecret
+    depends_on:
+      - minio-0
+
+volumes:
+  minio_0_data_0:
+    driver: local
+  minio_0_data_1:
+    driver: local
+  minio_1_data_0:
+    driver: local
+  minio_1_data_1:
+    driver: local
+  minio_2_data_0:
+    driver: local
+  minio_2_data_1:
+    driver: local
+  minio_3_data_0:
+    driver: local
+  minio_3_data_1:
+    driver: local

--- a/docker-compose-distributed-multidrive.yml
+++ b/docker-compose-distributed-multidrive.yml
@@ -7,20 +7,14 @@ services:
       - /bin/bash
       - -ec
       - |
-        chmod -R g+rwX /data-0-0 /data-0-1 /data-1-0 /data-1-1 /data-2-0 /data-2-1 /data-3-0 /data-3-1
+        chmod -R g+rwX /data-0-0 /data-0-1 /data-1-0 /data-1-1
     volumes:
       - 'minio_0_data_0:/data-0-0'
       - 'minio_0_data_1:/data-0-1'
       - 'minio_1_data_0:/data-1-0'
       - 'minio_1_data_1:/data-1-1'
-      - 'minio_2_data_0:/data-2-0'
-      - 'minio_2_data_1:/data-2-1'
-      - 'minio_3_data_0:/data-3-0'
-      - 'minio_3_data_1:/data-3-1'
   minio-0:
     image: 'docker.io/bitnami/minio:2021-debian-10'
-    ports:
-      - 9000:9000
     volumes:
       - 'minio_0_data_0:/data-0'
       - 'minio_0_data_1:/data-1'
@@ -28,7 +22,7 @@ services:
       - MINIO_ACCESS_KEY=minio
       - MINIO_SECRET_KEY=miniosecret
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
-      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_DISTRIBUTED_NODES=minio-{0...1}/data-{0...1}
       - MINIO_SKIP_CLIENT=yes
     depends_on:
       - prepare-data
@@ -41,33 +35,7 @@ services:
       - MINIO_ACCESS_KEY=minio
       - MINIO_SECRET_KEY=miniosecret
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
-      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
-      - MINIO_SKIP_CLIENT=yes
-    depends_on:
-      - prepare-data
-  minio-2:
-    image: 'docker.io/bitnami/minio:2021-debian-10'
-    volumes:
-      - 'minio_2_data_0:/data-0'
-      - 'minio_2_data_1:/data-1'
-    environment:
-      - MINIO_ACCESS_KEY=minio
-      - MINIO_SECRET_KEY=miniosecret
-      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
-      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
-      - MINIO_SKIP_CLIENT=yes
-    depends_on:
-      - prepare-data
-  minio-3:
-    image: 'docker.io/bitnami/minio:2021-debian-10'
-    volumes:
-      - 'minio_3_data_0:/data-0'
-      - 'minio_3_data_1:/data-1'
-    environment:
-      - MINIO_ACCESS_KEY=minio
-      - MINIO_SECRET_KEY=miniosecret
-      - MINIO_DISTRIBUTED_MODE_ENABLED=yes
-      - MINIO_DISTRIBUTED_NODES=minio-{0...3}/data-{0...1}
+      - MINIO_DISTRIBUTED_NODES=minio-{0...1}/data-{0...1}
       - MINIO_SKIP_CLIENT=yes
     depends_on:
       - prepare-data
@@ -92,12 +60,4 @@ volumes:
   minio_1_data_0:
     driver: local
   minio_1_data_1:
-    driver: local
-  minio_2_data_0:
-    driver: local
-  minio_2_data_1:
-    driver: local
-  minio_3_data_0:
-    driver: local
-  minio_3_data_1:
     driver: local

--- a/docker-compose-distributed-multidrive.yml
+++ b/docker-compose-distributed-multidrive.yml
@@ -23,7 +23,6 @@ services:
       - MINIO_SECRET_KEY=miniosecret
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio-{0...1}/data-{0...1}
-      - MINIO_SKIP_CLIENT=yes
     depends_on:
       - prepare-data
   minio-1:
@@ -36,21 +35,8 @@ services:
       - MINIO_SECRET_KEY=miniosecret
       - MINIO_DISTRIBUTED_MODE_ENABLED=yes
       - MINIO_DISTRIBUTED_NODES=minio-{0...1}/data-{0...1}
-      - MINIO_SKIP_CLIENT=yes
     depends_on:
       - prepare-data
-  minio-client:
-    image: 'docker.io/bitnami/minio-client:2021-debian-10'
-    entrypoint:
-      - sleep
-    command:
-      - infinity
-    environment:
-      - MINIO_SERVER_HOST=minio-0
-      - MINIO_SERVER_ACCESS_KEY=minio
-      - MINIO_SERVER_SECRET_KEY=miniosecret
-    depends_on:
-      - minio-0
 
 volumes:
   minio_0_data_0:


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds the MinIO image the ability to use the ellipsis syntax to setup the distributed mode using the "ellipsis syntax" to define the MinIO nodes and drives to use.

**Benefits**

- Flexibility
- Production environments.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

See https://docs.min.io/docs/distributed-minio-quickstart-guide.html
